### PR TITLE
Fix repo link in header GitHub button

### DIFF
--- a/site/pages/_Layout.astro
+++ b/site/pages/_Layout.astro
@@ -17,6 +17,8 @@ import { Image, getImage } from 'astro:assets'
 const previewOptimized = await getImage({ src: preview, format: 'png' })
 const image = new URL(previewOptimized.src, import.meta.env.PROD ? 'https://fluid.tw' : Astro.url)
 
+const repo = pkg.repository.url.replace(/^git\+/, '').replace(/\.git$/, '')
+
 type Props = MDXLayoutProps<{
 	title: string
 	headline: string
@@ -76,7 +78,7 @@ const path = relative(root, file)
 				<span class="text-slate-700 dark:text-slate-200">Fluid for Tailwind CSS</span>
 			</div>
 			<a
-				href={pkg.repository.url.replace('git+','')}
+				href={repo}
 				class="ml-auto block text-slate-400 hover:text-slate-500 dark:hover:text-slate-300"
 				aria-label="View on GitHub"
 			>
@@ -136,7 +138,7 @@ const path = relative(root, file)
 			</div>
 			<a
 				class="hover:text-slate-900 dark:hover:text-slate-400"
-				href={`${pkg.repository}/edit/main/${path}`}>Edit this page on GitHub</a
+				href={`${repo}/edit/main/${path}`}>Edit this page on GitHub</a
 			>
 		</footer>
 	</div>

--- a/site/pages/_Layout.astro
+++ b/site/pages/_Layout.astro
@@ -76,7 +76,7 @@ const path = relative(root, file)
 				<span class="text-slate-700 dark:text-slate-200">Fluid for Tailwind CSS</span>
 			</div>
 			<a
-				href={pkg.repository}
+				href={pkg.repository.url.replace('git+','')}
 				class="ml-auto block text-slate-400 hover:text-slate-500 dark:hover:text-slate-300"
 				aria-label="View on GitHub"
 			>


### PR DESCRIPTION
Currently the the header link points to the the object inside of `package.json``.

I've patched it so it uses the URL property of the repo object, with a string replace to omit the prepending `git+` in the URL structure. This prevents it from 404'ing now.